### PR TITLE
Fixes SendRequestResult type name

### DIFF
--- a/en/MonoTouch.CoreFoundation/SendRequestResult.xml
+++ b/en/MonoTouch.CoreFoundation/SendRequestResult.xml
@@ -1,4 +1,4 @@
-<Type Name="MemoryPressureFlags" FullName="MonoTouch.CoreFoundation.SendRequestResult">
+<Type Name="SendRequestResult" FullName="MonoTouch.CoreFoundation.SendRequestResult">
   <TypeSignature Language="C#" Value="public enum SendRequestResult" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed SendRequestResult extends [mscorlib]System.Enum" />
   <AssemblyInfo apistyle="classic">


### PR DESCRIPTION
This breaks the documentation generated for VS, since the type name was duplicated.
